### PR TITLE
Add preview to Admin Settings page

### DIFF
--- a/lib/Settings/Admin.php
+++ b/lib/Settings/Admin.php
@@ -19,13 +19,13 @@
  *
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
- * 
- * 
-SPDX-FileCopyrightText: Opinsys Oy <dev@opinsys.fi>
-SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ *
+ * SPDX-FileCopyrightText: Opinsys Oy <dev@opinsys.fi>
+ * SPDX-License-Identifier: AGPL-3.0-or-later
  *
  */
- 
+
 namespace OCA\ExternalPortal\Settings;
 
 use OCP\AppFramework\Http\TemplateResponse;
@@ -40,26 +40,26 @@ use OCA\ExternalPortal\AppInfo\Application;
 
 class Admin implements ISettings {
 
-        /** @var IConfig */
-        private $config;
+	/** @var IConfig */
+	private $config;
 
-        /** @var IL10N */
-        private $l;
+	/** @var IL10N */
+	private $l;
 
-        /**
-         * Admin constructor.
-         *
-         * @param IConfig $config
-         * @param IL10N $l
-         */
-        public function __construct(IConfig $config,
-                                                                IL10N $l,
-				    IInitialState $initialStateService
-        ) {
-                $this->config = $config;
-                $this->l = $l;
+	/**
+	 * Admin constructor.
+	 *
+	 * @param IConfig $config
+	 * @param IL10N $l
+	 */
+	public function __construct(IConfig       $config,
+								IL10N         $l,
+								IInitialState $initialStateService) {
+		$this->config = $config;
+		$this->l = $l;
 		$this->initialStateService = $initialStateService;
-        }
+	}
+
 	/**
 	 * @return TemplateResponse
 	 */

--- a/src/AdminSettings.vue
+++ b/src/AdminSettings.vue
@@ -22,42 +22,75 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 
 <template>
 	<div id="externalportal_prefs" class="section">
-		<h2>
-			External portal settings
-		</h2>
-		<label for="externaportal-widget-title">
-			<span class="icon icon-file" />
-			Widget title
-		</label>
-		<input id="externaportal-widget-title"
-			v-model="state.widgetTitle"
-			type="text"
-			:class="{ 'icon-loading-small': saving }"
-			:placeholder="('External portal')">
-		<br>
-		<label for="extraWide">Make the widget wider when there are many links</label>
-		<input v-model="state.extraWide" type="checkbox" name="extraWide">
-		<br>
-		<label for="maxSize">Limit maximum icon size to to avoid over-stretching 32x32 pixmap icons</label>
-		<input v-model="state.maxSize" type="checkbox" name="maxSize">
-		<br>
-		<label for="showFiles">Show Files link for everyone</label>
-		<input v-model="state.showFiles" type="checkbox" name="showFiles">
-		<br>
-		<button color="primary" @click="saveSettings">
-			Save
-		</button>
+		<div class="settings">
+			<h2>
+				External portal settings
+			</h2>
+			<div class="setting">
+				<label for="externaportal-widget-title">
+					<span class="icon icon-file"/>
+					Widget title
+				</label>
+				<input id="externaportal-widget-title"
+					   v-model="state.widgetTitle"
+					   type="text"
+					   :class="{ 'icon-loading-small': saving }"
+					   :placeholder="('External portal')">
+			</div>
+			<div class="setting">
+				<label for="extraWide">Make the widget wider when there are many links</label>
+				<input v-model="state.extraWide" type="checkbox" name="extraWide">
+			</div>
+			<div class="setting">
+				<label for="maxSize">Limit maximum icon size to to avoid over-stretching 32x32 pixmap icons</label>
+				<input v-model="state.maxSize" type="checkbox" name="maxSize">
+			</div>
+			<div class="setting">
+				<label for="showFiles">Show Files link for everyone</label>
+				<input v-model="state.showFiles" type="checkbox" name="showFiles">
+			</div>
+			<div class="setting">
+				<button color="primary" @click="saveSettings">
+					Save
+				</button>
+			</div>
+		</div>
+		<div class="right-pane">
+			<h2>Preview</h2>
+			<div class="panel-wrapper">
+				<div class="panel">
+					<div class="panel--header">
+						<h2>
+							<div aria-labelledby="panel--header--icon--description"
+								 aria-hidden="true"
+								 class="icon-externalportal"
+								 role="img"/>
+							{{ this.state.widgetTitle || "External Portal" }}
+						</h2>
+						<span id="panel--header--icon--description" class="hidden-visually">
+							{{ t('dashboard', '"{title} icon"', {title: this.state.widgetTitle || "External Portal"}) }}
+						</span>
+					</div>
+					<div class="panel--content">
+						<Dashboard ref="dashboard" :title="this.state.widgetTitle"></Dashboard>
+					</div>
+				</div>
+			</div>
+		</div>
 	</div>
 </template>
 
 <script>
-import { loadState } from '@nextcloud/initial-state'
+import {loadState} from '@nextcloud/initial-state'
 import axios from '@nextcloud/axios'
-import { generateUrl } from '@nextcloud/router'
-import { showSuccess, showError } from '@nextcloud/dialogs'
+import {generateUrl} from '@nextcloud/router'
+import {showSuccess, showError} from '@nextcloud/dialogs'
+import Dashboard from "./Dashboard.vue";
+
 export default {
 	name: 'AdminSettings',
 	components: {
+		Dashboard
 	},
 	props: [],
 	data() {
@@ -67,7 +100,7 @@ export default {
 		}
 	},
 	methods: {
-		saveSettings() {
+		async saveSettings() {
 			this.saving = true
 			const values = {
 				widgetTitle: this.state.widgetTitle,
@@ -80,21 +113,74 @@ export default {
 			}
 			const url = generateUrl('/apps/externalportal/admin-config')
 			console.debug('"' + JSON.stringify(req) + '"')
-			axios.put(url, req)
-				.then((response) => {
-					showSuccess(t('externalportal', 'External portal options saved'))
-				})
-				.catch((error) => {
-					showError(
-						t('externalportal', 'Failed to save external portal options')
-						+ ': ' + (error.response?.request?.responseText ?? '')
-					)
-					console.debug(error)
-				})
-				.then(() => {
-					this.saving = false
-				})
-		},
+			try {
+				await axios.put(url, req)
+			} catch (e) {
+				showError(t('externalportal', 'Failed to save external portal options') + `: ${error.response?.request?.responseText ?? ''}`)
+				console.debug(error)
+			}
+			showSuccess(t('externalportal', 'External portal options saved'))
+			this.saving = false
+			await this.$refs.dashboard.reload()
+		}
 	},
 }
 </script>
+
+<style scoped>
+#externalportal_prefs {
+	display: flex;
+	flex-direction: row;
+	justify-content: space-evenly;
+	flex-wrap: wrap;
+}
+
+.settings {
+	display: flex;
+	flex-direction: column;
+	flex-shrink: 0;
+}
+
+.right-pane {
+	margin: 16px;
+}
+
+.panel-wrapper {
+	background-color: var(--color-background-plain, var(--color-main-background));
+	padding: 16px;
+}
+
+.panel {
+	width: 320px;
+	max-width: 100%;
+	background-color: var(--color-main-background-blur);
+	box-sizing: border-box;
+	backdrop-filter: var(--filter-background-blur);
+	-webkit-backdrop-filter: var(--filter-background-blur);
+	border-radius: var(--border-radius-large);
+}
+
+.panel--header {
+	padding: 16px;
+	cursor: grab;
+}
+
+.panel--content {
+	margin: 0 16px 16px 16px;
+	height: 424px;
+	overflow: visible;
+	box-sizing: border-box;
+}
+
+.icon-externalportal {
+	background-image: url('../img/externalportal-dark.svg');
+	filter: var(--background-invert-if-dark);
+	background-size: 32px;
+	width: 32px;
+	height: 32px;
+	margin-right: 16px;
+	background-position: center;
+	float: left;
+}
+
+</style>

--- a/src/Dashboard.vue
+++ b/src/Dashboard.vue
@@ -22,15 +22,15 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 
 <template>
 	<div id="external-portal-widget">
-		<div v-if="loading" class="icon icon-loading" />
+		<div v-if="loading" class="icon icon-loading"/>
 		<span v-else-if="number > 0">
 			<div v-for="item in content"
-				:key="item.id"
-				:class="{ smaller: content.length>4 && content.length < 7, smallest: content.length>6, maxsized: maxSize}">
+				 :key="item.id"
+				 :class="{ smaller: content.length>4 && content.length < 7, smallest: content.length>6, maxsized: maxSize}">
 				<a v-bind="{ target: item.sameWindow ? '' : '_blank' }" :href="item.url">
 					<img class="linkitem"
-						preserveAspectRatio="xMinYMin meet"
-						:src="item.icon">
+						 preserveAspectRatio="xMinYMin meet"
+						 :src="item.icon">
 					<span class="linkname">
 						{{ item.name }}
 					</span>
@@ -46,13 +46,12 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 <script>
 
 import axios from '@nextcloud/axios'
-import { generateOcsUrl, generateUrl } from '@nextcloud/router'
-import { translate as t } from '@nextcloud/l10n'
+import {generateOcsUrl, generateUrl} from '@nextcloud/router'
+import {translate as t} from '@nextcloud/l10n'
 
 export default {
 	name: 'Dashboard',
-	components: {
-	},
+	components: {},
 	props: {
 		title: {
 			type: String,
@@ -69,8 +68,7 @@ export default {
 			showFiles: false,
 		}
 	},
-	computed: {
-	},
+	computed: {},
 	beforeMount() {
 		this.getConfig()
 		this.getContent()
@@ -78,48 +76,62 @@ export default {
 	mounted() {
 	},
 	methods: {
-		getConfig() {
+		async getConfig() {
 			const url = generateUrl('/apps/externalportal/config')
-			axios.get(url).then((response) => {
+			try {
+				const response = await axios.get(url)
+				console.debug('"' + JSON.stringify(response.data) + '"')
 				this.extraWide = response.data.extraWide
 				this.maxSize = response.data.maxSize
 				this.showFiles = response.data.showFiles
-				console.debug('"' + JSON.stringify(response.data) + '"')
-			}).catch((error) => {
-				console.debug(error)
-			}).then(() => {
-				if (this.showFiles) {
-					const filesUrl = generateUrl('/apps/files')
-					const filesIconUrl = generateUrl('../apps/files/img/app.svg')
-					const filesLabel = t('files', 'Files')
-					this.content = [{ icon: filesIconUrl, url: filesUrl, name: filesLabel, sameWindow: true }].concat(this.content)
-					this.number = this.content.length
-				}
-				if (this.number > 6 && this.extraWide) {
-					document.getElementById('external-portal-widget').parentNode.parentNode.style.width = '400px'
-				}
-			})
+			} catch (e) {
+				console.log(e)
+			}
+
+			if (this.showFiles) {
+				const filesUrl = generateUrl('/apps/files')
+				const filesIconUrl = generateUrl('../apps/files/img/app.svg')
+				const filesLabel = t('files', 'Files')
+				this.content = [{
+					icon: filesIconUrl,
+					url: filesUrl,
+					name: filesLabel,
+					sameWindow: true
+				}].concat(this.content)
+				this.number = this.content.length
+			}
+			if (this.number > 6 && this.extraWide) {
+				document.getElementById('external-portal-widget').parentNode.parentNode.style.width = '400px'
+			}
 		},
 
-		getContent() {
+		async getContent() {
 			let url = generateOcsUrl('apps/external/api/v1', 2)
 			if (url.endsWith('/')) { // behaviour seems to have changed between 24 and 25
 				url = url.slice(0, -1)
 			}
-			axios.get(url).then((response) => {
+			try {
+				const response = await axios.get(url)
 				this.content = this.content.concat(response.data.ocs.data)
 				this.number = this.content.length
 				console.debug('"' + JSON.stringify(response.data) + '"')
 				console.debug('"' + JSON.stringify(this.content) + '"')
-			}).catch((error) => {
+			} catch (error) {
 				console.debug(error)
-			}).then(() => {
-				this.loading = false
-				if (this.number > 6 && this.extraWide) {
-					document.getElementById('external-portal-widget').parentNode.parentNode.style.width = '400px'
-				}
-			})
+			}
+			this.loading = false
+			if (this.number > 6 && this.extraWide) {
+				document.getElementById('external-portal-widget').parentNode.parentNode.style.width = '400px'
+			}
 		},
+		async reload() {
+			this.loading = true
+			document.getElementById('external-portal-widget').parentNode.parentNode.style.width = '320px'
+			this.content = []
+			this.number = 0
+			await this.getConfig()
+			await this.getContent()
+		}
 	},
 }
 </script>
@@ -139,32 +151,39 @@ div {
 
 	img {
 		padding: 0.5rem;
-    -webkit-filter: drop-shadow(5px 5px 5px #888);
-    filter: drop-shadow(5px 5px 5px #888);
+		-webkit-filter: drop-shadow(5px 5px 5px #888);
+		filter: drop-shadow(5px 5px 5px #888);
 	}
+
 	.linkname {
-	position: relative;
-	top: -0.75rem;
+		position: relative;
+		top: -0.75rem;
 	}
 }
+
 div.icon-loading {
 	margin: 1rem;
 }
+
 div.smaller {
 	width: 39%;
 }
+
 div.smallest {
 	width: 30%;
 }
+
 div.maxsized {
 	max-width: 64px;
 	margin: 0.5rem;
 }
+
 .linkitem {
 	width: 95%;
 	height: 95%;
 	margin-top: 0.5rem;
 }
+
 .linkitem:hover {
 	transition: transform .2s;
 	transform: scale(1.1);


### PR DESCRIPTION
I like your app and recently had the issue, that it doesn't play very well with 1) theming and 2) light/dark mode, because the contrast between the icons and the widget isn't guaranteed to be good.
So I decided to attempt implementing options for dynamic icon colors. This PR is a preparation for the second one which adds the actual feature :)

Adds a preview to the admin settings page

![image](https://github.com/puavo-org/externalportal/assets/6317548/36d75ffe-4172-42e8-9f98-1dedf9ff2d82)

